### PR TITLE
Fixed Action Button shortcut

### DIFF
--- a/Oberron/UI/Features/Home/HomeView.swift
+++ b/Oberron/UI/Features/Home/HomeView.swift
@@ -9,8 +9,11 @@ import SwiftUI
 
 struct HomeView: View {
 	@Environment(NavigationService.self) var navService
+	@Environment(\.scenePhase) private var scenePhase
 	
 	@State private var isVisible = false
+	@State private var isInteractive = false
+	@State private var pendingNavigationTask: Task<Void, Never>?
 	
 	var body: some View {
 		VStack {
@@ -66,21 +69,40 @@ struct HomeView: View {
 				.staggeredEntrance(isVisible: isVisible)
 		}
 		.padding(20)
+		.allowsHitTesting(isInteractive)
 		.onAppear {
 			isVisible = true
+			lockInteractionTemporarily()
+		}
+		.onChange(of: scenePhase) { oldPhase, newPhase in
+			if newPhase == .active && oldPhase == .background {
+				lockInteractionTemporarily()
+			}
+		}
+		.onDisappear {
+			pendingNavigationTask?.cancel()
+		}
+	}
+	
+	private func lockInteractionTemporarily() {
+		isInteractive = false
+		DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+			isInteractive = true
 		}
 	}
 	
 	private func exitAndNavigate(to route: NavRoute) {
+		guard isInteractive else { return }
+		isInteractive = false
 		isVisible = false
 		
-		DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-			navService.navigate(to: route)
+		pendingNavigationTask?.cancel()
+		pendingNavigationTask = Task {
+			try? await Task.sleep(for: .seconds(1.0))
+			guard !Task.isCancelled else { return }
+			if navService.currentRoute == .home {
+				navService.navigate(to: route)
+			}
 		}
 	}
-}
-
-#Preview {
-	HomeView()
-		.environment(NavigationService())
 }


### PR DESCRIPTION
Fixed the action button shortcut, when starting a session from Action Button the home screen is shown for quite a bit of time and the user can interact with the screen.

This fix disables any interaction while in the transition home phase.

The delay is inevitable when dealing with Action Button, and trying to eliminate it is more complicated.

This closes #64.
This closes #64.
